### PR TITLE
Fix typo on programId (again)

### DIFF
--- a/lib/aws_agcod/create_gift_card.rb
+++ b/lib/aws_agcod/create_gift_card.rb
@@ -21,7 +21,7 @@ class AGCOD
 
       @response = request.create("CreateGiftCard", {
         "creationRequestId" => request_id,
-        "programID" => program_id,
+        "programId" => program_id,
         "value" => {
           "currencyCode" => currency,
           "amount" => amount

--- a/lib/aws_agcod/version.rb
+++ b/lib/aws_agcod/version.rb
@@ -1,3 +1,3 @@
 class AGCOD
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end


### PR DESCRIPTION
Apparently their docs page is just wrong and the correct parameter name is `programId` with a lowercase "d" at the end.
Here's the full context: https://tremendous-rewards.slack.com/archives/C042N0W2T44/p1714498077752269